### PR TITLE
Revert "Bump node-fetch from 2.6.9 to 3.3.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@octokit/plugin-throttling": "^5.0.1",
     "glob": "^8.0.3",
     "mime": "^3.0.0",
-    "node-fetch": "^3.3.0"
+    "node-fetch": "^2.6.7"
   },
   "devDependencies": {
     "@types/glob": "^8.0.0",


### PR DESCRIPTION
Reverts jge162/create-release#35